### PR TITLE
fix build error on armbian on armvh

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ For Kernel 4.15.x ~ 5.11.x (Linux Mint, Ubuntu or Debian Derivatives)
 
 ## How to install (for arm devices)
 
+`sudo ln -s /lib/modules/$(uname -r)/build/arch/arm /lib/modules/$(uname -r)/build/arch/armv7l`
+
 `sudo apt-get install build-essential git dkms linux-headers-$(uname -r)`
 
 `git clone -b arm https://github.com/kelebek333/rtl8188fu rtl8188fu-arm`


### PR DESCRIPTION
make search for armv71 instead of arm on 32 bit platforms. Add command make a symbolic link to correct directory and fix build problem. It mention on other driver build instructions for arm devices:
https://github.com/brektrou/rtl8821CU#arm-architecture-tweak-for-this-driver-this-solves-compilation-problem-of-this-driver