### PR TITLE
Fix fallthrough warning

### DIFF
--- a/core/rtw_mlme_ext.c
+++ b/core/rtw_mlme_ext.c
@@ -1188,7 +1188,9 @@ void mgt_dispatcher(_adapter *padapter, union recv_frame *precv_frame)
 				ptable->func = &OnAuth;
 			else
 				ptable->func = &OnAuthClient;
-			//pass through
+#if defined(fallthrough)
+			fallthrough;
+#endif
 		case WIFI_ASSOCREQ:
 		case WIFI_REASSOCREQ:
 			_mgt_dispatcher(padapter, ptable, precv_frame);	

--- a/hal/rtl8188f/usb/usb_halinit.c
+++ b/hal/rtl8188f/usb/usb_halinit.c
@@ -764,6 +764,9 @@ static void usb_AggSettingRxUpdate(PADAPTER padapter)
 		aggctrl &= ~RXDMA_AGG_EN;
 		aggrx &= ~BIT_USB_RXDMA_AGG_EN;
 		rxdmamode &= ~BIT_DMA_MODE;
+#if defined(fallthrough)
+		fallthrough;
+#endif
 	default:
 		DBG_8192C("%s: RX Aggregation Disable!\n", __func__);
 		break;


### PR DESCRIPTION
Fix fallthrough warning
warning: this statement may fall through [-Wimplicit-fallthrough=]
Credits => https://github.com/lwfinger/rtl8188fu/commit/2614aaf4ee0420f2e3efd62d7de19f7bc719ff66