### PR TITLE
Reduce debug logging in kernel logs (dmesg)

### DIFF
--- a/include/autoconf.h
+++ b/include/autoconf.h
@@ -302,7 +302,7 @@
 /*
  * Debug Related Configure
  */
-#define CONFIG_DEBUG /* DBG_871X, etc... */
+// #define CONFIG_DEBUG /* DBG_871X, etc... */
 #ifdef CONFIG_DEBUG
 	#define DBG	1	/* for ODM & BTCOEX debug */
 	#define DBG_PHYDM_MORE 0
@@ -315,7 +315,7 @@
 	#define CONFIG_DEBUG_RTL871X /* RT_TRACE, RT_PRINT_DATA, _func_enter_, _func_exit_ */
 #endif /* DBG_MORE */
 
-#define CONFIG_PROC_DEBUG
+// #define CONFIG_PROC_DEBUG
 
 /*
 #define DBG_CONFIG_ERROR_DETECT


### PR DESCRIPTION
Thank you for maintaining this fork, 🙏 I am successfully using the rtl8188fu module with a WiFi USB dongle on a Raspberry Pi 2 and balenaOS. 🎉 
I did however notice a very large amount of debug logging in the output of `dmesg` and `journalctl` that obscures other system logging — as similarly reported in https://github.com/gnab/rtl8812au/issues/49.
This trivial PR significantly reduces the amount of debug logging. Even with this PR, some debug logging still remains, mainly instances of `DBG_871X_LEVEL(_drv_always_, ...)` with messages such as ["nolinked power save enter"](https://github.com/kelebek333/rtl8188fu/blob/master/core/rtw_pwrctrl.c#L90), but this PR goes a long way and effectively solves the problem.
