### PR TITLE
ISO C90: fix the APIs to compile with standard and replace void * with unsigned long

### DIFF
--- a/hal/rtl8188f/usb/usb_ops.c
+++ b/hal/rtl8188f/usb/usb_ops.c
@@ -487,7 +487,7 @@ _exit_recvbuf2recvframe:
 }
 
 
-void rtl8188fu_xmit_tasklet(void *priv)
+void rtl8188fu_xmit_tasklet(unsigned long priv)
 {
 	int ret = _FALSE;
 	_adapter *padapter = (_adapter *)priv;

--- a/include/rtl8188f_xmit.h
+++ b/include/rtl8188f_xmit.h
@@ -313,7 +313,7 @@ s32 rtl8188fu_hal_xmit(PADAPTER padapter, struct xmit_frame *pxmitframe);
 s32 rtl8188fu_mgnt_xmit(PADAPTER padapter, struct xmit_frame *pmgntframe);
 s32	 rtl8188fu_hal_xmitframe_enqueue(_adapter *padapter, struct xmit_frame *pxmitframe);
 //s32 rtl8812au_xmit_buf_handler(PADAPTER padapter);
-void rtl8188fu_xmit_tasklet(void *priv);
+void rtl8188fu_xmit_tasklet(unsigned long priv);
 s32 rtl8188fu_xmitframe_complete(_adapter *padapter, struct xmit_priv *pxmitpriv, struct xmit_buf *pxmitbuf);
 void _dbg_dump_tx_info(_adapter	*padapter,int frame_tag,struct tx_desc *ptxdesc);
 #endif

--- a/include/usb_ops.h
+++ b/include/usb_ops.h
@@ -89,7 +89,7 @@ void interrupt_handler_8192eu(_adapter *padapter, u16 pkt_len, u8 *pbuf);
 void rtl8188fu_set_hw_type(struct dvobj_priv *pdvobj);
 void rtl8188fu_set_intf_ops(struct _io_ops *pops);
 void rtl8188fu_recv_tasklet(void *priv);
-void rtl8188fu_xmit_tasklet(void *priv);
+void rtl8188fu_xmit_tasklet(unsigned long priv);
 #ifdef CONFIG_SUPPORT_USB_INT
 void interrupt_handler_8188fu(_adapter *padapter, u16 pkt_len, u8 *pbuf);
 #endif

--- a/include/usb_ops_linux.h
+++ b/include/usb_ops_linux.h
@@ -79,7 +79,7 @@ int usb_write16(struct intf_hdl *pintfhdl, u32 addr, u16 val);
 int usb_write32(struct intf_hdl *pintfhdl, u32 addr, u32 val);
 int usb_writeN(struct intf_hdl *pintfhdl, u32 addr, u32 length, u8 *pdata);
 u32 usb_read_port(struct intf_hdl *pintfhdl, u32 addr, u32 cnt, u8 *rmem);
-void usb_recv_tasklet(void *priv);
+void usb_recv_tasklet(unsigned long priv);
 
 #ifdef CONFIG_USB_INTERRUPT_IN_PIPE
 void usb_read_interrupt_complete(struct urb *purb, struct pt_regs *regs);

--- a/os_dep/linux/ioctl_mp.c
+++ b/os_dep/linux/ioctl_mp.c
@@ -48,7 +48,7 @@ int rtw_mp_write_reg(struct net_device *dev,
 	u32 addr, data;
 	int ret;
 	PADAPTER padapter = rtw_netdev_priv(dev);
-	char input[wrqu->length];
+	char* input = kmalloc(wrqu->length, GFP_KERNEL);
 
 	if (copy_from_user(input, wrqu->pointer, wrqu->length))
 		return -EFAULT;
@@ -111,6 +111,7 @@ int rtw_mp_write_reg(struct net_device *dev,
 		break;
 	}
 
+	kfree(input);
 	return ret;
 }
 
@@ -130,7 +131,7 @@ int rtw_mp_read_reg(struct net_device *dev,
 					struct iw_request_info *info,
 					struct iw_point *wrqu, char *extra)
 {
-	char input[wrqu->length];
+	char* input = kmalloc(wrqu->length, GFP_KERNEL);
 	char *pch, *pnext, *ptmp;
 	char *width_str;
 	char width;
@@ -244,6 +245,7 @@ int rtw_mp_read_reg(struct net_device *dev,
 			break;
 		}
 
+	kfree(input);
 	return ret;
 }
 
@@ -262,7 +264,7 @@ int rtw_mp_write_rf(struct net_device *dev,
 	u32 path, addr, data;
 	int ret;
 	PADAPTER padapter = rtw_netdev_priv(dev);
-	char input[wrqu->length];
+	char* input = kmalloc(wrqu->length, GFP_KERNEL);
 
 
 	_rtw_memset(input, 0, wrqu->length);
@@ -288,6 +290,7 @@ int rtw_mp_write_rf(struct net_device *dev,
 	sprintf(extra, "write_rf completed\n");
 	wrqu->length = strlen(extra);
 
+	kfree(input);
 	return 0;
 }
 
@@ -304,7 +307,7 @@ int rtw_mp_read_rf(struct net_device *dev,
 				   struct iw_request_info *info,
 				   struct iw_point *wrqu, char *extra)
 {
-	char input[wrqu->length];
+	char* input = kmalloc(wrqu->length, GFP_KERNEL);
 	char *pch, *pnext, *ptmp;
 	char data[20], tmp[20], buf[3];
 	u32 path, addr, strtou;
@@ -356,6 +359,7 @@ int rtw_mp_read_rf(struct net_device *dev,
 	}
 	wrqu->length = strlen(extra);
 
+	kfree(input);
 	return 0;
 }
 
@@ -410,7 +414,7 @@ int rtw_mp_rate(struct net_device *dev,
 				struct iw_point *wrqu, char *extra)
 {
 	u32 rate = MPT_RATE_1M;
-	u8		input[wrqu->length];
+	u8* input = kmalloc(wrqu->length, GFP_KERNEL);
 	PADAPTER padapter = rtw_netdev_priv(dev);
 	PMPT_CONTEXT		pMptCtx = &(padapter->mppriv.MptCtx);
 
@@ -447,6 +451,7 @@ int rtw_mp_rate(struct net_device *dev,
 	SetDataRate(padapter);
 
 	wrqu->length = strlen(extra);
+	kfree(input);
 	return 0;
 }
 
@@ -458,7 +463,7 @@ int rtw_mp_channel(struct net_device *dev,
 
 	PADAPTER padapter = rtw_netdev_priv(dev);
 	HAL_DATA_TYPE	*pHalData	= GET_HAL_DATA(padapter);
-	u8		input[wrqu->length];
+	u8* input = kmalloc(wrqu->length, GFP_KERNEL);
 	u32	channel = 1;
 	int cur_ch_offset;
 
@@ -474,6 +479,7 @@ int rtw_mp_channel(struct net_device *dev,
 	pHalData->CurrentChannel = channel;
 
 	wrqu->length = strlen(extra);
+	kfree(input);
 	return 0;
 }
 
@@ -486,7 +492,7 @@ int rtw_mp_bandwidth(struct net_device *dev,
 	int cur_ch_offset;
 	PADAPTER padapter = rtw_netdev_priv(dev);
 	HAL_DATA_TYPE	*pHalData	= GET_HAL_DATA(padapter);
-	u8 input[wrqu->length];
+	u8* input = kmalloc(wrqu->length, GFP_KERNEL);
 
 	if (copy_from_user(input, wrqu->pointer, wrqu->length))
 		return -EFAULT;
@@ -510,6 +516,7 @@ int rtw_mp_bandwidth(struct net_device *dev,
 	/*set_channel_bwmode(padapter, padapter->mppriv.channel, cur_ch_offset, bandwidth);*/
 	wrqu->length = strlen(extra);
 
+	kfree(input);
 	return 0;
 }
 
@@ -519,7 +526,7 @@ int rtw_mp_txpower_index(struct net_device *dev,
 						 struct iw_point *wrqu, char *extra)
 {
 	PADAPTER padapter = rtw_netdev_priv(dev);
-	char input[wrqu->length];
+	char* input = kmalloc(wrqu->length, GFP_KERNEL);
 	u32 rfpath;
 	u32 txpower_inx;
 
@@ -534,6 +541,7 @@ int rtw_mp_txpower_index(struct net_device *dev,
 	sprintf(extra, " %d", txpower_inx);
 	wrqu->length = strlen(extra);
 
+	kfree(input);
 	return 0;
 }
 
@@ -544,7 +552,7 @@ int rtw_mp_txpower(struct net_device *dev,
 {
 	u32 idx_a = 0, idx_b = 0, idx_c = 0, idx_d = 0, status = 0;
 	int MsetPower = 1;
-	u8		input[wrqu->length];
+	u8* input = kmalloc(wrqu->length, GFP_KERNEL);
 
 	PADAPTER padapter = rtw_netdev_priv(dev);
 	PMPT_CONTEXT		pMptCtx = &(padapter->mppriv.MptCtx);
@@ -573,6 +581,7 @@ int rtw_mp_txpower(struct net_device *dev,
 	}
 
 	wrqu->length = strlen(extra);
+	kfree(input);
 	return 0;
 }
 
@@ -582,7 +591,7 @@ int rtw_mp_ant_tx(struct net_device *dev,
 				  struct iw_point *wrqu, char *extra)
 {
 	u8 i;
-	u8		input[wrqu->length];
+	u8* input = kmalloc(wrqu->length, GFP_KERNEL);
 	u16 antenna = 0;
 	PADAPTER padapter = rtw_netdev_priv(dev);
 	HAL_DATA_TYPE	*pHalData = GET_HAL_DATA(padapter);
@@ -618,6 +627,7 @@ int rtw_mp_ant_tx(struct net_device *dev,
 	SetAntenna(padapter);
 
 	wrqu->length = strlen(extra);
+	kfree(input);
 	return 0;
 }
 
@@ -628,7 +638,7 @@ int rtw_mp_ant_rx(struct net_device *dev,
 {
 	u8 i;
 	u16 antenna = 0;
-	u8		input[wrqu->length];
+	u8* input = kmalloc(wrqu->length, GFP_KERNEL);
 	PADAPTER padapter = rtw_netdev_priv(dev);
 	HAL_DATA_TYPE	*pHalData = GET_HAL_DATA(padapter);
 
@@ -664,6 +674,7 @@ int rtw_mp_ant_rx(struct net_device *dev,
 	SetAntenna(padapter);
 	wrqu->length = strlen(extra);
 
+	kfree(input);
 	return 0;
 }
 
@@ -804,7 +815,7 @@ int rtw_mp_disable_bt_coexist(struct net_device *dev,
 	HAL_DATA_TYPE	*pHalData = GET_HAL_DATA(padapter);
 	struct hal_ops *pHalFunc = &padapter->HalFunc;
 
-	u8 input[wrqu->data.length];
+	u8* input = kmalloc(wrqu->data.length, GFP_KERNEL);
 	u32 bt_coexist;
 
 	if (copy_from_user(input, wrqu->data.pointer, wrqu->data.length))
@@ -832,6 +843,7 @@ int rtw_mp_disable_bt_coexist(struct net_device *dev,
 #endif
 	}
 
+	kfree(input);
 	return 0;
 }
 
@@ -842,7 +854,7 @@ int rtw_mp_arx(struct net_device *dev,
 {
 	int bStartRx = 0, bStopRx = 0, bQueryPhy = 0, bQueryMac = 0, bSetBssid = 0;
 	int bmac_filter = 0, bfilter_init = 0, bmon = 0, bSmpCfg = 0, bloopbk = 0;
-	u8		input[wrqu->length];
+	u8* input = kmalloc(wrqu->length, GFP_KERNEL);
 	char *pch, *ptmp, *token, *tmp[2] = {0x00, 0x00};
 	u32 i = 0, ii = 0, jj = 0, kk = 0, cnts = 0, ret;
 	PADAPTER padapter = rtw_netdev_priv(dev);
@@ -978,6 +990,7 @@ int rtw_mp_arx(struct net_device *dev,
 
 	wrqu->length = strlen(extra) + 1;
 
+	kfree(input);
 	return 0;
 }
 
@@ -1020,7 +1033,7 @@ int rtw_mp_pwrtrk(struct net_device *dev,
 	s32 ret;
 	PADAPTER padapter = rtw_netdev_priv(dev);
 	HAL_DATA_TYPE			*pHalData = GET_HAL_DATA(padapter);
-	u8		input[wrqu->length];
+	u8* input = kmalloc(wrqu->length, GFP_KERNEL);
 
 	if (copy_from_user(input, wrqu->pointer, wrqu->length))
 		return -EFAULT;
@@ -1048,6 +1061,7 @@ int rtw_mp_pwrtrk(struct net_device *dev,
 
 	wrqu->length = strlen(extra);
 
+	kfree(input);
 	return 0;
 }
 
@@ -1058,7 +1072,7 @@ int rtw_mp_psd(struct net_device *dev,
 			   struct iw_point *wrqu, char *extra)
 {
 	PADAPTER padapter = rtw_netdev_priv(dev);
-	u8		input[wrqu->length];
+	u8* input = kmalloc(wrqu->length, GFP_KERNEL);
 
 	if (copy_from_user(input, wrqu->pointer, wrqu->length))
 		return -EFAULT;
@@ -1067,6 +1081,7 @@ int rtw_mp_psd(struct net_device *dev,
 
 	wrqu->length = mp_query_psd(padapter, extra);
 
+	kfree(input);
 	return 0;
 }
 
@@ -1162,7 +1177,7 @@ int rtw_mp_dump(struct net_device *dev,
 	struct mp_priv *pmp_priv;
 	struct pkt_attrib *pattrib;
 	u32 value;
-	u8		input[wrqu->length];
+	u8* input = kmalloc(wrqu->length, GFP_KERNEL);
 	u8 rf_type, path_nums = 0;
 	u32 i, j = 1, path;
 	PADAPTER padapter = rtw_netdev_priv(dev);
@@ -1177,6 +1192,7 @@ int rtw_mp_dump(struct net_device *dev,
 		bb_reg_dump(RTW_DBGDUMP, padapter);
 		rf_reg_dump(RTW_DBGDUMP, padapter);
 	}
+	kfree(input);
 	return 0;
 }
 
@@ -1188,7 +1204,7 @@ int rtw_mp_phypara(struct net_device *dev,
 
 	PADAPTER padapter = rtw_netdev_priv(dev);
 	HAL_DATA_TYPE	*pHalData	= GET_HAL_DATA(padapter);
-	char	input[wrqu->length];
+	char* input = kmalloc(wrqu->length, GFP_KERNEL);
 	u32		valxcap, ret;
 
 	if (copy_from_user(input, wrqu->pointer, wrqu->length))
@@ -1204,6 +1220,7 @@ int rtw_mp_phypara(struct net_device *dev,
 	sprintf(extra, "Set xcap=%d", valxcap);
 	wrqu->length = strlen(extra) + 1;
 
+	kfree(input);
 	return 0;
 
 }
@@ -1214,7 +1231,7 @@ int rtw_mp_SetRFPath(struct net_device *dev,
 					 struct iw_point *wrqu, char *extra)
 {
 	PADAPTER padapter = rtw_netdev_priv(dev);
-	char	input[wrqu->length];
+	char* input = kmalloc(wrqu->length, GFP_KERNEL);
 	int		bMain = 1, bTurnoff = 1;
 
 	DBG_871X("%s:iwpriv in=%s\n", __func__, input);
@@ -1239,6 +1256,7 @@ int rtw_mp_SetRFPath(struct net_device *dev,
 
 	wrqu->length = strlen(extra);
 	
+	kfree(input);
 	return 0;
 }
 
@@ -1248,7 +1266,7 @@ int rtw_mp_QueryDrv(struct net_device *dev,
 					union iwreq_data *wrqu, char *extra)
 {
 	PADAPTER padapter = rtw_netdev_priv(dev);
-	char	input[wrqu->data.length];
+	char* input = kmalloc(wrqu->data.length, GFP_KERNEL);
 	int	qAutoLoad = 1;
 
 	PHAL_DATA_TYPE pHalData = GET_HAL_DATA(padapter);
@@ -1268,6 +1286,7 @@ int rtw_mp_QueryDrv(struct net_device *dev,
 			sprintf(extra, "ok");
 	}
 	wrqu->data.length = strlen(extra) + 1;
+	kfree(input);
 	return 0;
 }
 
@@ -1277,7 +1296,7 @@ int rtw_mp_PwrCtlDM(struct net_device *dev,
 					struct iw_point *wrqu, char *extra)
 {
 	PADAPTER padapter = rtw_netdev_priv(dev);
-	u8		input[wrqu->length];
+	u8* input = kmalloc(wrqu->length, GFP_KERNEL);
 	int		bstart = 1;
 
 	if (copy_from_user(input, wrqu->pointer, wrqu->length))
@@ -1293,6 +1312,7 @@ int rtw_mp_PwrCtlDM(struct net_device *dev,
 	}
 	wrqu->length = strlen(extra);
 
+	kfree(input);
 	return 0;
 }
 
@@ -1900,7 +1920,7 @@ int rtw_mp_hwtx(struct net_device *dev,
 	PMPT_CONTEXT		pMptCtx = &(padapter->mppriv.MptCtx);
 
 #if	defined(CONFIG_RTL8814A) || defined(CONFIG_RTL8821B) || defined(CONFIG_RTL8822B)
-	u8		input[wrqu->data.length];
+	u8* input = malloc(wrqu->data.length, GFP_KERNEL);
 
 	if (copy_from_user(input, wrqu->data.pointer, wrqu->data.length))
 			return -EFAULT;
@@ -1912,6 +1932,7 @@ int rtw_mp_hwtx(struct net_device *dev,
 	sprintf(extra, "Set PMac Tx Mode start\n");
 
 	wrqu->data.length = strlen(extra);
+	kfree(input);
 #endif
 	return 0;
 

--- a/os_dep/linux/usb_ops_linux.c
+++ b/os_dep/linux/usb_ops_linux.c
@@ -741,7 +741,7 @@ void usb_init_recvbuf(_adapter *padapter, struct recv_buf *precvbuf)
 int recvbuf2recvframe(PADAPTER padapter, void *ptr);
 
 #ifdef CONFIG_USE_USB_BUFFER_ALLOC_RX
-void usb_recv_tasklet(void *priv)
+void usb_recv_tasklet(unsigned long priv)
 {	
 	struct recv_buf *precvbuf = NULL;
 	_adapter	*padapter = (_adapter*)priv;
@@ -904,7 +904,7 @@ _func_exit_;
 }
 #else	// CONFIG_USE_USB_BUFFER_ALLOC_RX
 
-void usb_recv_tasklet(void *priv)
+void usb_recv_tasklet(unsigned long priv)
 {
 	_pkt			*pskb;
 	_adapter		*padapter = (_adapter*)priv;


### PR DESCRIPTION
As of the standard ISO C90 constant value should be given to the char array, so changed that to dynamic allocation,

char input[data->length];
	|
	|
	|
	▼
char* input = kmalloc(data->length, GFP_KERNEL);

Another bug fixed for the, instead of parsing void * to the func parse unsigned long as per the kernel API.

It fixes the compile time errors and warnings.