### PR TITLE
Fix kernel 6.12 compatibility

### DIFF
--- a/install-rtl8188fu.sh
+++ b/install-rtl8188fu.sh
@@ -8,7 +8,8 @@ echo -e "${BLUE}Installing the dependencies...${NC}"
 sudo apt-get install build-essential git dkms linux-headers-$(uname -r)
 
 echo -e "\n${BLUE}Installing the driver...${NC}"
-sudo dkms install ./rtl8188fu
+sudo dkms install ../rtl8188fu
+mkdir -p /lib/firmware/rtlwifi
 sudo cp ./rtl8188fu/firmware/rtl8188fufw.bin /lib/firmware/rtlwifi/
 
 echo -e "\n${BLUE}Configuring the driver...${NC}"
@@ -24,5 +25,5 @@ echo 'alias usb:v0BDApF179d*dc*dsc*dp*icFFiscFFipFFin* rtl8188fu' | sudo tee /et
 
 echo -e "${BLUE}Activating the driver...${NC}"
 sudo update-initramfs -u
-sudo modprobe -r rtl8188fu
+sudo modprobe rtl8188fu
 

--- a/install-rtl8188fu.sh
+++ b/install-rtl8188fu.sh
@@ -7,9 +7,6 @@ YELLOW='\033[0;33m'
 echo -e "${BLUE}Installing the dependencies...${NC}"
 sudo apt-get install build-essential git dkms linux-headers-$(uname -r)
 
-echo -e "\n${BLUE}Copying the git...${NC}"
-git clone https://github.com/kelebek333/rtl8188fu
-
 echo -e "\n${BLUE}Installing the driver...${NC}"
 sudo dkms install ./rtl8188fu
 sudo cp ./rtl8188fu/firmware/rtl8188fufw.bin /lib/firmware/rtlwifi/

--- a/install-rtl8188fu.sh
+++ b/install-rtl8188fu.sh
@@ -10,7 +10,7 @@ sudo apt-get install build-essential git dkms linux-headers-$(uname -r)
 echo -e "\n${BLUE}Installing the driver...${NC}"
 sudo dkms install ../rtl8188fu
 mkdir -p /lib/firmware/rtlwifi
-sudo cp ./rtl8188fu/firmware/rtl8188fufw.bin /lib/firmware/rtlwifi/
+sudo cp ./firmware/rtl8188fufw.bin /lib/firmware/rtlwifi/
 
 echo -e "\n${BLUE}Configuring the driver...${NC}"
 sudo mkdir -p /etc/modprobe.d/

--- a/install-rtl8188fu.sh
+++ b/install-rtl8188fu.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+NC='\033[0m'
+BLUE='\033[0;34m'
+YELLOW='\033[0;33m'
+
+echo -e "${BLUE}Installing the dependencies...${NC}"
+sudo apt-get install build-essential git dkms linux-headers-$(uname -r)
+
+echo -e "\n${BLUE}Copying the git...${NC}"
+git clone https://github.com/kelebek333/rtl8188fu
+
+echo -e "\n${BLUE}Installing the driver...${NC}"
+sudo dkms install ./rtl8188fu
+sudo cp ./rtl8188fu/firmware/rtl8188fufw.bin /lib/firmware/rtlwifi/
+
+echo -e "\n${BLUE}Configuring the driver...${NC}"
+sudo mkdir -p /etc/modprobe.d/
+sudo touch /etc/modprobe.d/rtl8188fu.conf
+echo "options rtl8188fu rtw_power_mgnt=0 rtw_enusbss=0 rtw_ips_mode=0" | sudo tee /etc/modprobe.d/rtl8188fu.conf
+
+sudo mkdir -p /etc/NetworkManager/conf.d/
+sudo touch /etc/NetworkManager/conf.d/disable-random-mac.conf
+echo "[device]\nwifi.scan-rand-mac-address=no" | sudo tee /etc/NetworkManager/conf.d/disable-random-mac.conf
+
+echo 'alias usb:v0BDApF179d*dc*dsc*dp*icFFiscFFipFFin* rtl8188fu' | sudo tee /etc/modprobe.d/rtl8xxxu-blacklist.conf
+
+echo -e "${BLUE}Activating the driver...${NC}"
+sudo update-initramfs -u
+sudo modprobe -r rtl8188fu
+

--- a/os_dep/linux/ioctl_cfg80211.c
+++ b/os_dep/linux/ioctl_cfg80211.c
@@ -4663,7 +4663,7 @@ static int	cfg80211_rtw_set_channel(struct wiphy *wiphy
 }
 
 static int cfg80211_rtw_set_monitor_channel(struct wiphy *wiphy
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 13, 0))
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 12, 0))
 											, struct net_device *netdev
 											, struct cfg80211_chan_def *chandef
 #elif (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 8, 0))


### PR DESCRIPTION
Fixes build error on Kernel 6.12 due to cfg80211 API pointer mismatch. Updated kernel version check from 6.13.0 to 6.12.0.